### PR TITLE
More embed types

### DIFF
--- a/UniSky/App.xaml.cs
+++ b/UniSky/App.xaml.cs
@@ -25,6 +25,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using UnhandledExceptionEventArgs = Windows.UI.Xaml.UnhandledExceptionEventArgs;
 
 namespace UniSky;
 
@@ -33,6 +34,8 @@ namespace UniSky;
 /// </summary>
 sealed partial class App : Application
 {
+    private ILogger<App> _logger;
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -43,8 +46,20 @@ sealed partial class App : Application
 
         this.InitializeComponent();
         this.Suspending += OnSuspending;
+        this.UnhandledException += OnUnhandledException;
+
+        _logger = ServiceContainer.Default.GetRequiredService<ILoggerFactory>()
+            .CreateLogger<App>();
 
         // ResourceContext.SetGlobalQualifierValue("Custom", "Twitter", ResourceQualifierPersistence.LocalMachine);
+    }
+
+    private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        _logger.LogError(e.Exception, "Unhandled exception!!");
+
+        // hate this
+        e.Handled = true;
     }
 
     private void ConfigureServices()

--- a/UniSky/Converters/VisibilityConverter.cs
+++ b/UniSky/Converters/VisibilityConverter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace UniSky.Converters;
+
+public class VisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is null)
+        {
+            return Visibility.Collapsed;
+        }
+
+        if (value is bool b)
+        {
+            return b ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        if (value is int i)
+        {
+            return i > 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        if (value is string str)
+        {
+            return string.IsNullOrWhiteSpace(str) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        if (value is IEnumerable e)
+        {
+            return e.OfType<object>().Any() ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/UniSky/DataTemplates/FeedTemplates.xaml
+++ b/UniSky/DataTemplates/FeedTemplates.xaml
@@ -22,7 +22,10 @@
                                              ImagesEmbedTemplate="{StaticResource ImagesEmbedContentTemplate}"
                                              VideoEmbedTemplate="{StaticResource VideoEmbedContentTemplate}"
                                              PostEmbedTemplate="{StaticResource PostEmbedContentTemplate}"
-                                             ExternalEmbedTemplate="{StaticResource ExternalEmbedContentTemplate}"/>
+                                             ExternalEmbedTemplate="{StaticResource ExternalEmbedContentTemplate}"
+                                             RecordWithMediaEmbedTemplate="{StaticResource RecordWithMediaEmbedContentTemplate}"/>
+    
+    <converters:VisibilityConverter x:Key="VisibilityConverter"/>
 
     <MenuFlyout x:Key="FeedItemMoreButtonFlyout"
                 w1809:Placement="BottomEdgeAlignedRight"
@@ -51,10 +54,34 @@
         <Setter Property="Foreground" Value="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"/>
     </Style>
 
+    <DataTemplate x:Key="RecordWithMediaEmbedContentTemplate" 
+               x:DataType="posts:PostEmbedRecordWithMediaViewModel">
+        <StackPanel>
+            <Grid x:Name="MediaContentContainer"
+                  Visibility="{Binding Media,Converter={StaticResource VisibilityConverter}}">
+                <ContentControl x:Name="MediaContent"
+                                Margin="0,4,0,0"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                Content="{Binding Media}"/>
+            </Grid>
+            <Grid x:Name="RecordContentContainer"
+                  Visibility="{Binding Record,Converter={StaticResource VisibilityConverter}}">
+                <ContentControl x:Name="RecordContent"
+                                Margin="0,4,0,0"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                Content="{Binding Record}"/>
+            </Grid>
+        </StackPanel>
+    </DataTemplate>
+
     <DataTemplate x:Key="ExternalEmbedContentTemplate" 
                   x:DataType="posts:PostEmbedExternalViewModel">
         <Button Style="{ThemeResource CleanButtonStyle}"
-                Command="{x:Bind OpenLinkCommand}"
+                Command="{Binding OpenLinkCommand}"
                 BorderBrush="{ThemeResource SystemControlSeparatorBrush}"
                 Padding="0"
                 extensions:Hairline.BorderThickness="1"
@@ -68,7 +95,7 @@
                 </Grid.RowDefinitions>
 
                 <Border x:Name="ThumbnailBox"
-                        x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(ThumbnailUrl), Mode=OneWay}"
+                        Visibility="{Binding ThumbnailUrl, Converter={StaticResource VisibilityConverter}}"
                         BorderBrush="{ThemeResource SystemControlSeparatorBrush}"
                         extensions:Hairline.BorderThickness="0,0,0,1">
                     <toolkit:ConstrainedBox AspectRatio="2:1">
@@ -81,21 +108,21 @@
                 <StackPanel Grid.Row="1"
                             Padding="8,8,8,4">
                     <TextBlock x:Name="TitleBlock"
-                               x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Title), Mode=OneWay}"
+                               Visibility="{Binding Title, Converter={StaticResource VisibilityConverter}}"
                                Grid.Row="0"
                                Grid.Column="1"
                                Style="{ThemeResource BaseTextBlockStyle}" 
-                               Text="{x:Bind Title}"
+                               Text="{Binding Title}"
                                VerticalAlignment="Bottom"
                                MaxLines="1"/>
 
                     <TextBlock x:Name="SubtitleBlock"
-                               x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Description), Mode=OneWay}"
+                               Visibility="{Binding Description, Converter={StaticResource VisibilityConverter}}"
                                Grid.Row="1"
                                Grid.Column="1"
                                Margin="0,2,0,0"
                                Style="{ThemeResource CaptionTextBlockStyle}" 
-                               Text="{x:Bind Description}"
+                               Text="{Binding Description}"
                                VerticalAlignment="Top"
                                MaxLines="2"/>
                 </StackPanel>
@@ -119,8 +146,7 @@
                 HorizontalContentAlignment="Stretch"
                 Padding="8">
             <StackPanel>
-            
-                <Button Command="{x:Bind Author.OpenProfileCommand}"
+                <Button Command="{Binding Author.OpenProfileCommand}"
                         CommandParameter="{Binding ElementName=SmallProfileEllipse}"
                         Style="{ThemeResource CleanButtonStyle}"
                         Padding="0"
@@ -154,37 +180,37 @@
                                    Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"                  
                                    VerticalAlignment="Top"
                                    TextTrimming="CharacterEllipsis">                
-                            <Run Text="{x:Bind Author.Name, Mode=OneWay}"           
+                            <Run Text="{Binding Author.Name, Mode=OneWay}"           
                                  FontWeight="Bold"                        
                                  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>                    
-                            <Run Text="{x:Bind Author.Handle, Mode=OneWay}"/>
+                            <Run Text="{Binding Author.Handle, Mode=OneWay}"/>
                         </TextBlock>
 
                         <TextBlock x:Name="DateBlock"
-                                   x:Phase="4"
                                    Grid.Column="2"
                                    Margin="2,0"
                                    Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}"
                                    Typography.NumeralAlignment="Tabular"
-                                   Text="{x:Bind Date}"/>
+                                   Text="{Binding Date}"/>
                     </Grid>
                 </Button>
 
                 <controls:RichTextBlock x:Name="MainContent"
-                                        x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Text)}"
-                                        Inlines="{x:Bind RichText.Facets}"
+                                        Visibility="{Binding Text, Converter={StaticResource VisibilityConverter}}"
+                                        Inlines="{Binding RichText.Facets}"
                                         TextWrapping="Wrap"
                                         Margin="0,2,0,0"
                                         IsTextSelectionEnabled="True"
                                         VerticalAlignment="Top"/>
 
                 <Grid x:Name="EmbedContentContainer"
-                      x:Load="{x:Bind converters:Static.NotNull(Embed)}"
-                      x:Phase="2">
+                      Visibility="{Binding Embed, Converter={StaticResource VisibilityConverter}}">
                     <ContentControl x:Name="EmbedContent"
                                     Margin="0,4,0,0"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
-                                    Content="{x:Bind Embed}"/>
+                                    Content="{Binding Embed}"/>
                 </Grid>
             </StackPanel>
         </Button>
@@ -418,6 +444,7 @@
                             CommandParameter="{Binding ElementName=ProfileEllipse}"
                             Style="{ThemeResource CleanButtonStyle}"
                             Padding="0"
+                            Margin="-1,0,0,0"
                             VerticalAlignment="Top">
                         <Ellipse x:Name="ProfileEllipse"
                                  Width="42" 

--- a/UniSky/DataTemplates/FeedTemplates.xaml
+++ b/UniSky/DataTemplates/FeedTemplates.xaml
@@ -25,6 +25,12 @@
                                              ExternalEmbedTemplate="{StaticResource ExternalEmbedContentTemplate}"
                                              RecordWithMediaEmbedTemplate="{StaticResource RecordWithMediaEmbedContentTemplate}"/>
     
+    <datatemplates:PostEmbedTemplateSelector x:Key="PostEmbedChildTemplateSelector"
+                                             ImagesEmbedTemplate="{StaticResource ImagesEmbedContentTemplate}"
+                                             VideoEmbedTemplate="{StaticResource VideoEmbedContentTemplate}"
+                                             PostEmbedTemplate="{StaticResource PostEmbedContentTemplate}"
+                                             ExternalEmbedTemplate="{StaticResource ExternalEmbedContentTemplate}"/>
+    
     <converters:VisibilityConverter x:Key="VisibilityConverter"/>
 
     <MenuFlyout x:Key="FeedItemMoreButtonFlyout"
@@ -63,16 +69,16 @@
                                 Margin="0,4,0,0"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
-                                ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                ContentTemplateSelector="{StaticResource PostEmbedChildTemplateSelector}"
                                 Content="{Binding Media}"/>
             </Grid>
             <Grid x:Name="RecordContentContainer"
-                  Visibility="{Binding Record,Converter={StaticResource VisibilityConverter}}">
+                  Visibility="{Binding Record, Converter={StaticResource VisibilityConverter}}">
                 <ContentControl x:Name="RecordContent"
                                 Margin="0,4,0,0"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
-                                ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                ContentTemplateSelector="{StaticResource PostEmbedChildTemplateSelector}"
                                 Content="{Binding Record}"/>
             </Grid>
         </StackPanel>

--- a/UniSky/DataTemplates/FeedTemplates.xaml
+++ b/UniSky/DataTemplates/FeedTemplates.xaml
@@ -18,6 +18,12 @@
     <SolidColorBrush x:Key="LikeBrush">#ea4298</SolidColorBrush>
     <SolidColorBrush x:Key="RetweetBrush">#5cefaa</SolidColorBrush>
 
+    <datatemplates:PostEmbedTemplateSelector x:Key="PostEmbedTemplateSelector"
+                                             ImagesEmbedTemplate="{StaticResource ImagesEmbedContentTemplate}"
+                                             VideoEmbedTemplate="{StaticResource VideoEmbedContentTemplate}"
+                                             PostEmbedTemplate="{StaticResource PostEmbedContentTemplate}"
+                                             ExternalEmbedTemplate="{StaticResource ExternalEmbedContentTemplate}"/>
+
     <MenuFlyout x:Key="FeedItemMoreButtonFlyout"
                 w1809:Placement="BottomEdgeAlignedRight"
                 not1809:Placement="Bottom">
@@ -36,7 +42,7 @@
                         Text="Report Post"
                         Icon="ReportHacked"/>
     </MenuFlyout>
-    
+
     <Style x:Key="FeedItemActionButtonStyle" TargetType="Button">
         <Setter Property="Padding" Value="8"/>
         <Setter Property="Margin" Value="0,0,8,0"/>
@@ -44,6 +50,145 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"/>
     </Style>
+
+    <DataTemplate x:Key="ExternalEmbedContentTemplate" 
+                  x:DataType="posts:PostEmbedExternalViewModel">
+        <Button Style="{ThemeResource CleanButtonStyle}"
+                Command="{x:Bind OpenLinkCommand}"
+                BorderBrush="{ThemeResource SystemControlSeparatorBrush}"
+                Padding="0"
+                extensions:Hairline.BorderThickness="1"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Border x:Name="ThumbnailBox"
+                        x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(ThumbnailUrl), Mode=OneWay}"
+                        BorderBrush="{ThemeResource SystemControlSeparatorBrush}"
+                        extensions:Hairline.BorderThickness="0,0,0,1">
+                    <toolkit:ConstrainedBox AspectRatio="2:1">
+                        <Image Source="{Binding ThumbnailUrl}"
+                           VerticalAlignment="Center"
+                           Stretch="UniformToFill"/>
+                    </toolkit:ConstrainedBox>
+                </Border>
+
+                <StackPanel Grid.Row="1"
+                            Padding="8,8,8,4">
+                    <TextBlock x:Name="TitleBlock"
+                               x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Title), Mode=OneWay}"
+                               Grid.Row="0"
+                               Grid.Column="1"
+                               Style="{ThemeResource BaseTextBlockStyle}" 
+                               Text="{x:Bind Title}"
+                               VerticalAlignment="Bottom"
+                               MaxLines="1"/>
+
+                    <TextBlock x:Name="SubtitleBlock"
+                               x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Description), Mode=OneWay}"
+                               Grid.Row="1"
+                               Grid.Column="1"
+                               Margin="0,2,0,0"
+                               Style="{ThemeResource CaptionTextBlockStyle}" 
+                               Text="{x:Bind Description}"
+                               VerticalAlignment="Top"
+                               MaxLines="2"/>
+                </StackPanel>
+
+                <TextBlock Grid.Row="2" 
+                           Text="{Binding Source}"
+                           Style="{ThemeResource CaptionTextBlockStyle}" 
+                           Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+                           MaxLines="1"
+                           Margin="8,0,8,8"/>
+            </Grid>
+        </Button>
+    </DataTemplate>
+
+    <DataTemplate x:Key="PostEmbedContentTemplate" 
+                  x:DataType="posts:PostEmbedPostViewModel">
+        <Button Style="{ThemeResource CleanButtonStyle}"
+                BorderBrush="{ThemeResource SystemControlSeparatorBrush}"
+                extensions:Hairline.BorderThickness="1"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Padding="8">
+            <StackPanel>
+            
+                <Button Command="{x:Bind Author.OpenProfileCommand}"
+                        CommandParameter="{Binding ElementName=SmallProfileEllipse}"
+                        Style="{ThemeResource CleanButtonStyle}"
+                        Padding="0"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Ellipse x:Name="SmallProfileEllipse" 
+                                 Width="20" 
+                                 Height="20"
+                                 Margin="0,0,8,0">
+                            <Ellipse.Fill>
+                                <ImageBrush>
+                                    <ImageBrush.ImageSource>
+                                        <BitmapImage UriSource="{Binding Author.AvatarUrl}"
+                                                     DecodePixelWidth="16"
+                                                     DecodePixelHeight="16"
+                                                     DecodePixelType="Logical"/>
+                                    </ImageBrush.ImageSource>
+                                </ImageBrush>
+                            </Ellipse.Fill>
+                        </Ellipse>
+
+                        <TextBlock Grid.Column="1"
+                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"                  
+                                   VerticalAlignment="Top"
+                                   TextTrimming="CharacterEllipsis">                
+                            <Run Text="{x:Bind Author.Name, Mode=OneWay}"           
+                                 FontWeight="Bold"                        
+                                 Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>                    
+                            <Run Text="{x:Bind Author.Handle, Mode=OneWay}"/>
+                        </TextBlock>
+
+                        <TextBlock x:Name="DateBlock"
+                                   x:Phase="4"
+                                   Grid.Column="2"
+                                   Margin="2,0"
+                                   Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}"
+                                   Typography.NumeralAlignment="Tabular"
+                                   Text="{x:Bind Date}"/>
+                    </Grid>
+                </Button>
+
+                <controls:RichTextBlock x:Name="MainContent"
+                                        x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Text)}"
+                                        Inlines="{x:Bind RichText.Facets}"
+                                        TextWrapping="Wrap"
+                                        Margin="0,2,0,0"
+                                        IsTextSelectionEnabled="True"
+                                        VerticalAlignment="Top"/>
+
+                <Grid x:Name="EmbedContentContainer"
+                      x:Load="{x:Bind converters:Static.NotNull(Embed)}"
+                      x:Phase="2">
+                    <ContentControl x:Name="EmbedContent"
+                                    Margin="0,4,0,0"
+                                    ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                    Content="{x:Bind Embed}"/>
+                </Grid>
+            </StackPanel>
+        </Button>
+    </DataTemplate>
 
     <DataTemplate x:Key="ImagesEmbedContentTemplate" 
                   x:DataType="posts:PostEmbedImagesViewModel">
@@ -210,10 +355,6 @@
         </toolkit:ConstrainedBox>
     </DataTemplate>
 
-    <datatemplates:PostEmbedTemplateSelector x:Key="PostEmbedTemplateSelector"
-                                             ImagesEmbedTemplate="{StaticResource ImagesEmbedContentTemplate}"
-                                             VideoEmbedTemplate="{StaticResource VideoEmbedContentTemplate}"/>
-
     <DataTemplate x:Key="FeedItemContentTemplate"
                   x:DataType="posts:PostViewModel">
         <StackPanel BorderBrush="{ThemeResource SystemControlRevealSeparatorBrush}"
@@ -305,29 +446,37 @@
                 </Grid>
 
                 <StackPanel Grid.Column="1">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"                  
+                    <Button Command="{x:Bind Author.OpenProfileCommand}"
+                            CommandParameter="{Binding ElementName=ProfileEllipse}"
+                            Style="{ThemeResource CleanButtonStyle}"
+                            Padding="0"
+                            VerticalAlignment="Top"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"                  
                                    VerticalAlignment="Top"
                                    TextTrimming="CharacterEllipsis">                
                              <Run Text="{x:Bind Author.Name, Mode=OneWay}"           
                                   FontWeight="Bold"                        
                                   Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>                    
                              <Run Text="{x:Bind Author.Handle, Mode=OneWay}"/>
-                        </TextBlock>
+                            </TextBlock>
 
-                        <TextBlock x:Name="DateBlock"
+                            <TextBlock x:Name="DateBlock"
                                    x:Phase="4"
                                    Grid.Column="1"
                                    Margin="4,0,0,0"
                                    Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}"
                                    Typography.NumeralAlignment="Tabular"
                                    Text="{x:Bind Date}"/>
-                    </Grid>
-                    
+                        </Grid>
+                    </Button>
+
                     <controls:RichTextBlock x:Name="MainContent"
                                             x:Load="{x:Bind converters:Static.NotNullOrWhiteSpace(Text)}"
                                             Inlines="{x:Bind RichText.Facets}"
@@ -340,9 +489,11 @@
                           x:Load="{x:Bind converters:Static.NotNull(Embed)}"
                           x:Phase="2">
                         <ContentControl x:Name="EmbedContent"
-                                            Margin="0,4,0,4"
-                                            ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
-                                            Content="{x:Bind Embed}"/>
+                                        Margin="0,4,0,4"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Stretch"
+                                        ContentTemplateSelector="{StaticResource PostEmbedTemplateSelector}"
+                                        Content="{x:Bind Embed}"/>
                     </Grid>
 
                     <Grid x:Name="Interactions">

--- a/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
+++ b/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
@@ -13,6 +13,8 @@ internal class PostEmbedTemplateSelector : DataTemplateSelector
 {
     public DataTemplate VideoEmbedTemplate { get; set; }
     public DataTemplate ImagesEmbedTemplate { get; set; }
+    public DataTemplate PostEmbedTemplate { get; set; }
+    public DataTemplate ExternalEmbedTemplate { get; set; }
 
     protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
     {
@@ -20,6 +22,8 @@ internal class PostEmbedTemplateSelector : DataTemplateSelector
         {
             PostEmbedImagesViewModel => ImagesEmbedTemplate,
             PostEmbedVideoViewModel => VideoEmbedTemplate,
+            PostEmbedPostViewModel => PostEmbedTemplate,
+            PostEmbedExternalViewModel => ExternalEmbedTemplate,
             _ => null,
         };
     }

--- a/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
+++ b/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
@@ -15,6 +15,7 @@ internal class PostEmbedTemplateSelector : DataTemplateSelector
     public DataTemplate ImagesEmbedTemplate { get; set; }
     public DataTemplate PostEmbedTemplate { get; set; }
     public DataTemplate ExternalEmbedTemplate { get; set; }
+    public DataTemplate RecordWithMediaEmbedTemplate { get; set; }
 
     protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
     {
@@ -24,7 +25,8 @@ internal class PostEmbedTemplateSelector : DataTemplateSelector
             PostEmbedVideoViewModel => VideoEmbedTemplate,
             PostEmbedPostViewModel => PostEmbedTemplate,
             PostEmbedExternalViewModel => ExternalEmbedTemplate,
-            _ => null,
+            PostEmbedRecordWithMediaViewModel => RecordWithMediaEmbedTemplate,
+            _ => new DataTemplate(),
         };
     }
 

--- a/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
+++ b/UniSky/DataTemplates/PostEmbedTemplateSelector.cs
@@ -26,7 +26,7 @@ internal class PostEmbedTemplateSelector : DataTemplateSelector
             PostEmbedPostViewModel => PostEmbedTemplate,
             PostEmbedExternalViewModel => ExternalEmbedTemplate,
             PostEmbedRecordWithMediaViewModel => RecordWithMediaEmbedTemplate,
-            _ => new DataTemplate(),
+            _ => null,
         };
     }
 

--- a/UniSky/Package.appxmanifest
+++ b/UniSky/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="24101WamWooWamRD.25225E497690B"
     Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B"
-    Version="1.0.156.0" />
+    Version="1.0.157.0" />
 
   <mp:PhoneIdentity PhoneProductId="d3ae258d-7752-4bdb-bb0c-b6cca57f9cd1" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/UniSky/Package.appxmanifest
+++ b/UniSky/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="24101WamWooWamRD.25225E497690B"
     Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B"
-    Version="1.0.154.0" />
+    Version="1.0.155.0" />
 
   <mp:PhoneIdentity PhoneProductId="d3ae258d-7752-4bdb-bb0c-b6cca57f9cd1" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/UniSky/Package.appxmanifest
+++ b/UniSky/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="24101WamWooWamRD.25225E497690B"
     Publisher="CN=0F22111D-EDF0-42F0-B58D-26C4C5C5054B"
-    Version="1.0.155.0" />
+    Version="1.0.156.0" />
 
   <mp:PhoneIdentity PhoneProductId="d3ae258d-7752-4bdb-bb0c-b6cca57f9cd1" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/UniSky/UniSky.csproj
+++ b/UniSky/UniSky.csproj
@@ -256,6 +256,8 @@
     <Compile Include="ViewModels\Notifications\NotificationsCollection.cs" />
     <Compile Include="ViewModels\Notifications\NotificationsPageViewModel.cs" />
     <Compile Include="ViewModels\Notifications\NotificationViewModel.cs" />
+    <Compile Include="ViewModels\Posts\PostEmbedExternalViewModel.cs" />
+    <Compile Include="ViewModels\Posts\PostEmbedPostViewModel.cs" />
     <Compile Include="ViewModels\Posts\PostEmbedVideoViewModel.cs" />
     <Compile Include="ViewModels\Profile\ProfileFeedViewModel.cs" />
     <Compile Include="ViewModels\Profile\ProfilePageViewModel.cs" />

--- a/UniSky/UniSky.csproj
+++ b/UniSky/UniSky.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Controls\Sheet\SheetRootControl.xaml.cs">
       <DependentUpon>SheetRootControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converters\VisibilityConverter.cs" />
     <Compile Include="Converters\Static.cs" />
     <Compile Include="DataTemplates\FeedItemTemplateSelector.cs" />
     <Compile Include="DataTemplates\PostEmbedTemplateSelector.cs" />
@@ -258,6 +259,7 @@
     <Compile Include="ViewModels\Notifications\NotificationViewModel.cs" />
     <Compile Include="ViewModels\Posts\PostEmbedExternalViewModel.cs" />
     <Compile Include="ViewModels\Posts\PostEmbedPostViewModel.cs" />
+    <Compile Include="ViewModels\Posts\PostEmbedRecordWithMediaViewModel.cs" />
     <Compile Include="ViewModels\Posts\PostEmbedVideoViewModel.cs" />
     <Compile Include="ViewModels\Profile\ProfileFeedViewModel.cs" />
     <Compile Include="ViewModels\Profile\ProfilePageViewModel.cs" />

--- a/UniSky/ViewModels/Posts/PostEmbedExternalViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedExternalViewModel.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FishyFlip.Lexicon;
+using FishyFlip.Lexicon.App.Bsky.Embed;
+using Windows.System;
+using Windows.UI.ViewManagement;
+
+namespace UniSky.ViewModels.Posts;
+
+public partial class PostEmbedExternalViewModel : PostEmbedViewModel
+{
+    private readonly Uri link;
+
+    [ObservableProperty]
+    private string title;
+    [ObservableProperty]
+    private string description;
+    [ObservableProperty]
+    private string thumbnailUrl;
+    [ObservableProperty]
+    private string source;
+
+    public PostEmbedExternalViewModel(ViewExternal embed) : base(embed)
+    {
+        if (embed.External is { } external)
+        {
+            link = new Uri(external.Uri);
+
+            Title = external.Title;
+            Description = external.Description;
+            ThumbnailUrl = external.Thumb;
+            Source = link.Host;
+        }
+    }
+
+    [RelayCommand]
+    private async Task OpenLinkAsync()
+    {
+        await Launcher.LaunchUriAsync(link, new LauncherOptions() { DesiredRemainingView = ViewSizePreference.UseLess });
+    }
+}

--- a/UniSky/ViewModels/Posts/PostEmbedExternalViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedExternalViewModel.cs
@@ -33,7 +33,7 @@ public partial class PostEmbedExternalViewModel : PostEmbedViewModel
 
             Title = external.Title;
             Description = external.Description;
-            ThumbnailUrl = external.Thumb;
+            ThumbnailUrl = external.Thumb ?? "";
             Source = link.Host;
         }
     }

--- a/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
@@ -39,7 +39,8 @@ public partial class PostEmbedPostViewModel : PostEmbedViewModel
         Text = post.Text;
         RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
         Author = new ProfileViewModel(view.Author);
-        Embed = PostViewModel.CreateEmbedViewModel(view.Embeds?.FirstOrDefault(), false);
+
+        Embed = PostViewModel.CreateEmbedViewModel(view.Embeds?.FirstOrDefault(), true);
 
         var timeSinceIndex = DateTime.Now - (view.IndexedAt.Value.ToLocalTime());
         var date = timeSinceIndex.Humanize(1, minUnit: Humanizer.Localisation.TimeUnit.Second);

--- a/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using FishyFlip.Lexicon;
+using FishyFlip.Lexicon.App.Bsky.Embed;
+using FishyFlip.Lexicon.App.Bsky.Feed;
+using FishyFlip.Lexicon.Tools.Ozone.Team;
+using Humanizer;
+using UniSky.ViewModels.Profile;
+using UniSky.ViewModels.Text;
+
+namespace UniSky.ViewModels.Posts;
+
+public partial class PostEmbedPostViewModel : PostEmbedViewModel
+{
+    private readonly ViewRecord view;
+    private readonly Post post;
+
+    [ObservableProperty]
+    private string text;
+    [ObservableProperty]
+    private RichTextViewModel richText;
+    [ObservableProperty]
+    private ProfileViewModel author;
+    [ObservableProperty]
+    private string date;
+    [ObservableProperty]
+    private PostEmbedViewModel embed;
+
+    public PostEmbedPostViewModel(ViewRecord view, Post post) : base(view)
+    {
+        this.view = view;
+        this.post = post;
+
+        Text = post.Text;
+        RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
+        Author = new ProfileViewModel(view.Author);
+        Embed = CreateEmbedViewModel(view.Embeds.FirstOrDefault());
+
+        var timeSinceIndex = DateTime.Now - (view.IndexedAt.Value.ToLocalTime());
+        var date = timeSinceIndex.Humanize(1, minUnit: Humanizer.Localisation.TimeUnit.Second);
+        Date = date;
+    }
+
+    private PostEmbedViewModel CreateEmbedViewModel(ATObject embed)
+    {
+        if (embed is null)
+            return null;
+
+        Debug.WriteLine(embed.GetType());
+
+        return embed switch
+        {
+            ViewImages images => new PostEmbedImagesViewModel(images),
+            ViewVideo video => new PostEmbedVideoViewModel(video),
+            ViewExternal external => new PostEmbedExternalViewModel(external),
+            _ => null
+        };
+    }
+}

--- a/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedPostViewModel.cs
@@ -39,26 +39,10 @@ public partial class PostEmbedPostViewModel : PostEmbedViewModel
         Text = post.Text;
         RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
         Author = new ProfileViewModel(view.Author);
-        Embed = CreateEmbedViewModel(view.Embeds.FirstOrDefault());
+        Embed = PostViewModel.CreateEmbedViewModel(view.Embeds?.FirstOrDefault(), false);
 
         var timeSinceIndex = DateTime.Now - (view.IndexedAt.Value.ToLocalTime());
         var date = timeSinceIndex.Humanize(1, minUnit: Humanizer.Localisation.TimeUnit.Second);
         Date = date;
-    }
-
-    private PostEmbedViewModel CreateEmbedViewModel(ATObject embed)
-    {
-        if (embed is null)
-            return null;
-
-        Debug.WriteLine(embed.GetType());
-
-        return embed switch
-        {
-            ViewImages images => new PostEmbedImagesViewModel(images),
-            ViewVideo video => new PostEmbedVideoViewModel(video),
-            ViewExternal external => new PostEmbedExternalViewModel(external),
-            _ => null
-        };
     }
 }

--- a/UniSky/ViewModels/Posts/PostEmbedRecordWithMediaViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedRecordWithMediaViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using FishyFlip.Lexicon;
+using FishyFlip.Lexicon.App.Bsky.Embed;
+
+namespace UniSky.ViewModels.Posts;
+
+public partial class PostEmbedRecordWithMediaViewModel : PostEmbedViewModel
+{
+    [ObservableProperty]
+    private PostEmbedViewModel record;
+    [ObservableProperty]
+    private PostEmbedViewModel media;
+
+    public PostEmbedRecordWithMediaViewModel(ViewRecordWithMedia embed) : base(embed)
+    {
+        Record = PostViewModel.CreateEmbedViewModel(embed.Record, true);
+        Media = PostViewModel.CreateEmbedViewModel(embed.Media, false);
+    }
+}

--- a/UniSky/ViewModels/Posts/PostEmbedRecordWithMediaViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedRecordWithMediaViewModel.cs
@@ -16,9 +16,9 @@ public partial class PostEmbedRecordWithMediaViewModel : PostEmbedViewModel
     [ObservableProperty]
     private PostEmbedViewModel media;
 
-    public PostEmbedRecordWithMediaViewModel(ViewRecordWithMedia embed) : base(embed)
+    public PostEmbedRecordWithMediaViewModel(ViewRecordWithMedia embed, bool isNested) : base(embed)
     {
-        Record = PostViewModel.CreateEmbedViewModel(embed.Record, true);
-        Media = PostViewModel.CreateEmbedViewModel(embed.Media, false);
+        Record = !isNested ? PostViewModel.CreateEmbedViewModel(embed.Record, isNested) : null;
+        Media = PostViewModel.CreateEmbedViewModel(embed.Media, true);
     }
 }

--- a/UniSky/ViewModels/Posts/PostEmbedVideoViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostEmbedVideoViewModel.cs
@@ -38,6 +38,6 @@ public partial class PostEmbedVideoViewModel : PostEmbedViewModel
     {
         var create = await AdaptiveMediaSource.CreateFromUriAsync(new Uri(video.Playlist));
         if (create.Status == AdaptiveMediaSourceCreationStatus.Success)
-            Source = MediaSource.CreateFromAdaptiveMediaSource(create.MediaSource);
+            Source = MediaSource.CreateFromAdaptiveMediaSource(create.MediaSource); 
     }
 }

--- a/UniSky/ViewModels/Posts/PostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostViewModel.cs
@@ -253,7 +253,7 @@ public partial class PostViewModel : ViewModelBase
         return n.ToMetric(decimals: 2);
     }
 
-    private PostEmbedViewModel CreateEmbedViewModel(ATObject embed)
+    internal static PostEmbedViewModel CreateEmbedViewModel(ATObject embed, bool allowNestedPosts = true)
     {
         if (embed is null)
             return null;
@@ -265,7 +265,8 @@ public partial class PostViewModel : ViewModelBase
             ViewImages images => new PostEmbedImagesViewModel(images),
             ViewVideo video => new PostEmbedVideoViewModel(video),
             ViewExternal external => new PostEmbedExternalViewModel(external),
-            ViewRecordDef and { Record: ViewRecord viewRecord } => viewRecord.Value switch
+            ViewRecordWithMedia recordWithMedia => new PostEmbedRecordWithMediaViewModel(recordWithMedia),
+            ViewRecordDef and { Record: ViewRecord viewRecord } when allowNestedPosts => viewRecord.Value switch
             {
                 Post post => new PostEmbedPostViewModel(viewRecord, post),
                 _ => null

--- a/UniSky/ViewModels/Posts/PostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostViewModel.cs
@@ -127,7 +127,7 @@ public partial class PostViewModel : ViewModelBase
 
         RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
         Author = new ProfileViewModel(view.Author);
-        Embed = CreateEmbedViewModel(view.Embed);
+        Embed = CreateEmbedViewModel(view.Embed, false);
 
         var timeSinceIndex = DateTime.Now - (view.IndexedAt.Value.ToLocalTime());
         var date = timeSinceIndex.Humanize(1, minUnit: Humanizer.Localisation.TimeUnit.Second);
@@ -253,7 +253,7 @@ public partial class PostViewModel : ViewModelBase
         return n.ToMetric(decimals: 2);
     }
 
-    internal static PostEmbedViewModel CreateEmbedViewModel(ATObject embed, bool allowNestedPosts = true)
+    internal static PostEmbedViewModel CreateEmbedViewModel(ATObject embed, bool isNested = false)
     {
         if (embed is null)
             return null;
@@ -265,8 +265,10 @@ public partial class PostViewModel : ViewModelBase
             ViewImages images => new PostEmbedImagesViewModel(images),
             ViewVideo video => new PostEmbedVideoViewModel(video),
             ViewExternal external => new PostEmbedExternalViewModel(external),
-            ViewRecordWithMedia recordWithMedia => new PostEmbedRecordWithMediaViewModel(recordWithMedia),
-            ViewRecordDef and { Record: ViewRecord viewRecord } when allowNestedPosts => viewRecord.Value switch
+            ViewRecordWithMedia recordWithMedia => isNested ? 
+                CreateEmbedViewModel(recordWithMedia.Media, isNested) :
+                new PostEmbedRecordWithMediaViewModel(recordWithMedia, isNested),
+            ViewRecordDef and { Record: ViewRecord viewRecord } when !isNested => viewRecord.Value switch
             {
                 Post post => new PostEmbedPostViewModel(viewRecord, post),
                 _ => null

--- a/UniSky/ViewModels/Posts/PostViewModel.cs
+++ b/UniSky/ViewModels/Posts/PostViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -124,11 +125,9 @@ public partial class PostViewModel : ViewModelBase
 
         HasChild = hasChild;
 
+        RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
         Author = new ProfileViewModel(view.Author);
         Embed = CreateEmbedViewModel(view.Embed);
-
-        RichText = new RichTextViewModel(post.Text, post.Facets ?? []);
-        //Debug.WriteLine(string.Concat(RichText.Facets.Select(f => f.Text)));
 
         var timeSinceIndex = DateTime.Now - (view.IndexedAt.Value.ToLocalTime());
         var date = timeSinceIndex.Humanize(1, minUnit: Humanizer.Localisation.TimeUnit.Second);
@@ -259,12 +258,18 @@ public partial class PostViewModel : ViewModelBase
         if (embed is null)
             return null;
 
-        //Debug.WriteLine(embed.GetType());
+        Debug.WriteLine(embed.GetType());
 
         return embed switch
         {
             ViewImages images => new PostEmbedImagesViewModel(images),
             ViewVideo video => new PostEmbedVideoViewModel(video),
+            ViewExternal external => new PostEmbedExternalViewModel(external),
+            ViewRecordDef and { Record: ViewRecord viewRecord } => viewRecord.Value switch
+            {
+                Post post => new PostEmbedPostViewModel(viewRecord, post),
+                _ => null
+            },
             _ => null
         };
     }


### PR DESCRIPTION
Adds support for `external`, `record` and `recordWithMedia` embed types, also removes `x:Bind` from any embed templates because UWP has a nasty habit of breaking DataContexts sometimes.