### PR TITLE
Split out "Overlays" and "Sheets"

### DIFF
--- a/UniSky/App.xaml.cs
+++ b/UniSky/App.xaml.cs
@@ -58,7 +58,7 @@ sealed partial class App : Application
         collection.AddSingleton<ITypedSettings, SettingsService>();
         collection.AddSingleton<IThemeService, ThemeService>();
         collection.AddSingleton<INavigationServiceLocator, NavigationServiceLocator>();
-        collection.AddScoped<ISafeAreaService, CoreWindowSafeAreaService>();
+        collection.AddScoped<ISafeAreaService, ApplicationViewSafeAreaService>();
         collection.AddScoped<ISheetService, SheetService>();
 
         collection.AddTransient<LoginService>();

--- a/UniSky/Controls/Compose/ComposeSheet.xaml
+++ b/UniSky/Controls/Compose/ComposeSheet.xaml
@@ -1,4 +1,5 @@
 ﻿<sheet:SheetControl
+    x:Uid="ComposeSheet"
     x:Class="UniSky.Controls.Compose.ComposeSheet"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -17,9 +18,6 @@
     PrimaryButtonCommand="{x:Bind ViewModel.PostCommand}"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.CanPost, Mode=OneWay}"
     SecondaryButtonCommand="{x:Bind ViewModel.HideCommand}">
-    <sheet:SheetControl.TitleContent>
-        <TextBlock x:Uid="ComposeSheetTitle" Text="NEW POST"/>
-    </sheet:SheetControl.TitleContent>
     <sheet:SheetControl.PrimaryButtonContent>
         <TextBlock x:Uid="ComposeSheetPrimaryText" Text="Post" Margin="8,0"/>
     </sheet:SheetControl.PrimaryButtonContent>

--- a/UniSky/Controls/Compose/ComposeSheet.xaml.cs
+++ b/UniSky/Controls/Compose/ComposeSheet.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using UniSky.Controls.Overlay;
 using UniSky.Controls.Sheet;
 using UniSky.Services;
 using UniSky.ViewModels.Compose;
@@ -48,7 +49,7 @@ namespace UniSky.Controls.Compose
         public bool Not(bool b, bool a)
             => !a && !b;
 
-        private void OnShowing(SheetControl sender, SheetShowingEventArgs e)
+        private void OnShowing(OverlayControl sender, OverlayShowingEventArgs e)
         {
             var inputPane = InputPane.GetForCurrentView();
             inputPane.Showing += OnInputPaneShowing;
@@ -73,7 +74,7 @@ namespace UniSky.Controls.Compose
             }
         }
 
-        private void OnHidden(SheetControl sender, RoutedEventArgs args)
+        private void OnHidden(OverlayControl sender, RoutedEventArgs args)
         {
             var inputPane = InputPane.GetForCurrentView();
             inputPane.Showing -= OnInputPaneShowing;
@@ -89,12 +90,12 @@ namespace UniSky.Controls.Compose
             }
         }
 
-        private void OnShown(SheetControl sender, RoutedEventArgs args)
+        private void OnShown(OverlayControl sender, RoutedEventArgs args)
         {
             PrimaryTextBox.Focus(FocusState.Programmatic);
         }
 
-        private async void OnHiding(SheetControl sender, SheetHidingEventArgs e)
+        private async void OnHiding(OverlayControl sender, OverlayHidingEventArgs e)
         {
             var deferral = e.GetDeferral();
             try

--- a/UniSky/Controls/Overlay/OverlayControl.cs
+++ b/UniSky/Controls/Overlay/OverlayControl.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UniSky.Services;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace UniSky.Controls.Overlay;
+
+[ContentProperty(Name = nameof(OverlayContent))]
+public abstract class OverlayControl : Control
+{
+    public static readonly DependencyProperty OverlayContentProperty =
+        DependencyProperty.Register("OverlayContent", typeof(object), typeof(OverlayControl), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty OverlayContentTemplateProperty =
+        DependencyProperty.Register("OverlayContentTemplate", typeof(DataTemplate), typeof(OverlayControl), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty TitleContentProperty =
+        DependencyProperty.Register("TitleContent", typeof(object), typeof(OverlayControl), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty TitleContentTemplateProperty =
+        DependencyProperty.Register("TitleContentTemplate", typeof(DataTemplate), typeof(OverlayControl), new PropertyMetadata(null));
+
+    public static readonly DependencyProperty PreferredWindowSizeProperty =
+        DependencyProperty.Register("PreferredWindowSize", typeof(Size), typeof(OverlayControl), new PropertyMetadata(new Size(320, 400)));
+
+    public IOverlayController Controller { get; private set; }
+
+    public object OverlayContent
+    {
+        get => (object)GetValue(OverlayContentProperty);
+        set => SetValue(OverlayContentProperty, value);
+    }
+
+    public DataTemplate OverlayContentTemplate
+    {
+        get => (DataTemplate)GetValue(OverlayContentTemplateProperty);
+        set => SetValue(OverlayContentTemplateProperty, value);
+    }
+
+    public object TitleContent
+    {
+        get => (object)GetValue(TitleContentProperty);
+        set => SetValue(TitleContentProperty, value);
+    }
+
+    public DataTemplate TitleContentTemplate
+    {
+        get => (DataTemplate)GetValue(TitleContentTemplateProperty);
+        set => SetValue(TitleContentTemplateProperty, value);
+    }
+
+    public Size PreferredWindowSize
+    {
+        get => (Size)GetValue(PreferredWindowSizeProperty);
+        set => SetValue(PreferredWindowSizeProperty, value);
+    }
+
+    public event TypedEventHandler<OverlayControl, RoutedEventArgs> Hidden;
+    public event TypedEventHandler<OverlayControl, OverlayHidingEventArgs> Hiding;
+    public event TypedEventHandler<OverlayControl, OverlayShowingEventArgs> Showing;
+    public event TypedEventHandler<OverlayControl, RoutedEventArgs> Shown;
+
+    internal void SetOverlayController(IOverlayController controller)
+    {
+        Controller = controller;
+    }
+
+    internal void InvokeHidden()
+    {
+        OnHidden(new RoutedEventArgs());
+    }
+
+    internal async Task<bool> InvokeHidingAsync()
+    {
+        var ev = new OverlayHidingEventArgs();
+        OnHiding(ev);
+
+        await ev.WaitOnDeferral();
+
+        return !ev.Cancel;
+    }
+
+    internal void InvokeShowing(object parameter)
+    {
+        OnShowing(new OverlayShowingEventArgs(parameter));
+    }
+
+    internal void InvokeShown()
+    {
+        OnShown(new RoutedEventArgs());
+    }
+
+    protected virtual void OnHiding(OverlayHidingEventArgs args)
+    {
+        Hiding?.Invoke(this, args);
+    }
+
+    protected virtual void OnHidden(RoutedEventArgs args)
+    {
+        Hidden?.Invoke(this, args);
+    }
+
+    protected virtual void OnShowing(OverlayShowingEventArgs args)
+    {
+        Showing?.Invoke(this, args);
+    }
+
+    protected virtual void OnShown(RoutedEventArgs args)
+    {
+        Shown?.Invoke(this, args);
+    }
+}

--- a/UniSky/Controls/Overlay/OverlayHidingEventArgs.cs
+++ b/UniSky/Controls/Overlay/OverlayHidingEventArgs.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+
+namespace UniSky.Controls.Overlay;
+
+public class OverlayHidingEventArgs : RoutedEventArgs
+{
+    private Deferral _deferral;
+    private TaskCompletionSource<object> _deferralCompletion;
+
+    public Deferral GetDeferral()
+    {
+        _deferralCompletion = new TaskCompletionSource<object>();
+        return (_deferral ??= new Deferral(OnDeferralCompleted));
+    }
+
+    public bool Cancel { get; set; } = false;
+
+    internal Task WaitOnDeferral()
+    {
+        if (_deferral == null)
+            return Task.CompletedTask;
+        else
+            return _deferralCompletion.Task;
+    }
+
+    private void OnDeferralCompleted()
+    {
+        _deferralCompletion?.SetResult(null);
+    }
+}

--- a/UniSky/Controls/Overlay/OverlayShowingEventArgs.cs
+++ b/UniSky/Controls/Overlay/OverlayShowingEventArgs.cs
@@ -1,0 +1,13 @@
+﻿using Windows.UI.Xaml;
+
+namespace UniSky.Controls.Overlay;
+
+public class OverlayShowingEventArgs : RoutedEventArgs
+{
+    public object Parameter { get; }
+
+    public OverlayShowingEventArgs(object parameter)
+    {
+        Parameter = parameter;
+    }
+}

--- a/UniSky/Controls/PreviewPaneAuroraControl.xaml.cs
+++ b/UniSky/Controls/PreviewPaneAuroraControl.xaml.cs
@@ -16,8 +16,8 @@ namespace System.Windows.Shell.Aurora
     {
         public Color Color
         {
-            get { return (Color)GetValue(ColorProperty); }
-            set { SetValue(ColorProperty, value); }
+            get => (Color)GetValue(ColorProperty);
+            set => SetValue(ColorProperty, value);
         }
 
         public static readonly DependencyProperty ColorProperty =
@@ -25,8 +25,8 @@ namespace System.Windows.Shell.Aurora
 
         public TimeSpan AnimationDuration
         {
-            get { return (TimeSpan)GetValue(AnimationDurationProperty); }
-            set { SetValue(AnimationDurationProperty, value); }
+            get => (TimeSpan)GetValue(AnimationDurationProperty);
+            set => SetValue(AnimationDurationProperty, value);
         }
 
         // Using a DependencyProperty as the backing store for AnimationDuration.  This enables animation, styling, binding, etc...

--- a/UniSky/Controls/RichTextBlock/RichTextBlock.cs
+++ b/UniSky/Controls/RichTextBlock/RichTextBlock.cs
@@ -22,8 +22,8 @@ namespace UniSky.Controls
 
         public TextWrapping TextWrapping
         {
-            get { return (TextWrapping)GetValue(TextWrappingProperty); }
-            set { SetValue(TextWrappingProperty, value); }
+            get => (TextWrapping)GetValue(TextWrappingProperty);
+            set => SetValue(TextWrappingProperty, value);
         }
 
         public static readonly DependencyProperty TextWrappingProperty =
@@ -31,8 +31,8 @@ namespace UniSky.Controls
 
         public bool IsTextSelectionEnabled
         {
-            get { return (bool)GetValue(IsTextSelectionEnabledProperty); }
-            set { SetValue(IsTextSelectionEnabledProperty, value); }
+            get => (bool)GetValue(IsTextSelectionEnabledProperty);
+            set => SetValue(IsTextSelectionEnabledProperty, value);
         }
 
         public static readonly DependencyProperty IsTextSelectionEnabledProperty =
@@ -40,8 +40,8 @@ namespace UniSky.Controls
 
         public IList<FacetInline> Inlines
         {
-            get { return (IList<FacetInline>)GetValue(InlinesProperty); }
-            set { SetValue(InlinesProperty, value); }
+            get => (IList<FacetInline>)GetValue(InlinesProperty);
+            set => SetValue(InlinesProperty, value);
         }
 
         public static readonly DependencyProperty InlinesProperty =

--- a/UniSky/Controls/Settings/SettingsSheet.xaml.cs
+++ b/UniSky/Controls/Settings/SettingsSheet.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using UniSky.Controls.Overlay;
 using UniSky.Controls.Sheet;
 using UniSky.Services;
 using UniSky.ViewModels.Settings;
@@ -19,12 +20,12 @@ public sealed partial class SettingsSheet : SheetControl
         this.Hiding += OnHiding;
     }
 
-    private void OnShowing(SheetControl sender, SheetShowingEventArgs args)
+    private void OnShowing(OverlayControl sender, OverlayShowingEventArgs args)
     {
         this.DataContext = ActivatorUtilities.CreateInstance<SettingsViewModel>(ServiceContainer.Scoped);
     }
 
-    private async void OnHiding(SheetControl sender, SheetHidingEventArgs args)
+    private async void OnHiding(OverlayControl sender, OverlayHidingEventArgs args)
     {
         if (!ApiInformation.IsMethodPresent("Windows.ApplicationModel.Core.CoreApplication", "RequestRestartAsync"))
             return;

--- a/UniSky/Controls/Sheet/SheetControl.cs
+++ b/UniSky/Controls/Sheet/SheetControl.cs
@@ -2,6 +2,7 @@
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using UniSky.Controls.Overlay;
 using UniSky.Services;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
@@ -9,301 +10,181 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 
-// The Templated Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234235
+namespace UniSky.Controls.Sheet;
 
-namespace UniSky.Controls.Sheet
+public class SheetControl : OverlayControl
 {
-    public class SheetShowingEventArgs : RoutedEventArgs
+    public object PrimaryButtonContent
     {
-        public object Parameter { get; }
+        get => (object)GetValue(PrimaryButtonContentProperty);
+        set => SetValue(PrimaryButtonContentProperty, value);
+    }
 
-        public SheetShowingEventArgs(object parameter)
+    public static readonly DependencyProperty PrimaryButtonContentProperty =
+        DependencyProperty.Register("PrimaryButtonContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
+
+    public DataTemplate PrimaryButtonContentTemplate
+    {
+        get => (DataTemplate)GetValue(PrimaryButtonContentTemplateProperty);
+        set => SetValue(PrimaryButtonContentTemplateProperty, value);
+    }
+
+    public static readonly DependencyProperty PrimaryButtonContentTemplateProperty =
+        DependencyProperty.Register("PrimaryButtonContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
+
+    public Visibility PrimaryButtonVisibility
+    {
+        get => (Visibility)GetValue(PrimaryButtonVisibilityProperty);
+        set => SetValue(PrimaryButtonVisibilityProperty, value);
+    }
+
+    public static readonly DependencyProperty PrimaryButtonVisibilityProperty =
+        DependencyProperty.Register("PrimaryButtonVisibility", typeof(Visibility), typeof(SheetControl), new PropertyMetadata(Visibility.Visible));
+
+    public ICommand PrimaryButtonCommand
+    {
+        get => (ICommand)GetValue(PrimaryButtonCommandProperty);
+        set => SetValue(PrimaryButtonCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty PrimaryButtonCommandProperty =
+        DependencyProperty.Register("PrimaryButtonCommand", typeof(ICommand), typeof(SheetControl), new PropertyMetadata(null));
+
+    public bool IsPrimaryButtonEnabled
+    {
+        get => (bool)GetValue(IsPrimaryButtonEnabledProperty);
+        set => SetValue(IsPrimaryButtonEnabledProperty, value);
+    }
+
+    public static readonly DependencyProperty IsPrimaryButtonEnabledProperty =
+        DependencyProperty.Register("IsPrimaryButtonEnabled", typeof(bool), typeof(SheetControl), new PropertyMetadata(true));
+
+    public object SecondaryButtonContent
+    {
+        get => (object)GetValue(SecondaryButtonContentProperty);
+        set => SetValue(SecondaryButtonContentProperty, value);
+    }
+
+    public static readonly DependencyProperty SecondaryButtonContentProperty =
+        DependencyProperty.Register("SecondaryButtonContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
+
+    public DataTemplate SecondaryButtonContentTemplate
+    {
+        get => (DataTemplate)GetValue(SecondaryButtonContentTemplateProperty);
+        set => SetValue(SecondaryButtonContentTemplateProperty, value);
+    }
+
+    public static readonly DependencyProperty SecondaryButtonContentTemplateProperty =
+        DependencyProperty.Register("SecondaryButtonContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
+
+    public Visibility SecondaryButtonVisibility
+    {
+        get => (Visibility)GetValue(SecondaryButtonVisibilityProperty);
+        set => SetValue(SecondaryButtonVisibilityProperty, value);
+    }
+
+    public static readonly DependencyProperty SecondaryButtonVisibilityProperty =
+        DependencyProperty.Register("SecondaryButtonVisibility", typeof(Visibility), typeof(SheetControl), new PropertyMetadata(Visibility.Visible));
+
+    public ICommand SecondaryButtonCommand
+    {
+        get => (ICommand)GetValue(SecondaryButtonCommandProperty);
+        set => SetValue(SecondaryButtonCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty SecondaryButtonCommandProperty =
+        DependencyProperty.Register("SecondaryButtonCommand", typeof(ICommand), typeof(SheetControl), new PropertyMetadata(null));
+
+    public bool IsSecondaryButtonEnabled
+    {
+        get => (bool)GetValue(IsSecondaryButtonEnabledProperty);
+        set => SetValue(IsSecondaryButtonEnabledProperty, value);
+    }
+
+    public static readonly DependencyProperty IsSecondaryButtonEnabledProperty =
+        DependencyProperty.Register("IsSecondaryButtonEnabled", typeof(bool), typeof(SheetControl), new PropertyMetadata(true));
+
+    public SheetControl()
+    {
+        this.DefaultStyleKey = typeof(SheetControl);
+
+        // default hide
+        this.SecondaryButtonCommand = new AsyncRelayCommand(() =>
         {
-            Parameter = parameter;
+            return Controller?.TryHideSheetAsync();
+        });
+    }
+
+    protected override void OnHidden(RoutedEventArgs args)
+    {
+        if (Controller.IsFullWindow)
+        {
+            Controller.SafeAreaService.SafeAreaUpdated -= OnSafeAreaUpdated;
+        }
+
+        base.OnHidden(args);
+    }
+
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        if (Controller != null && Controller.IsFullWindow)
+        {
+            VisualStateManager.GoToState(this, "FullWindow", false);
+            var titleBarDragArea = this.FindDescendantByName("TitleBarDragArea");
+            Controller.SafeAreaService.SafeAreaUpdated += OnSafeAreaUpdated;
+            Controller.SafeAreaService.SetTitleBar(titleBarDragArea);
+
+            var inputPane = InputPane.GetForCurrentView();
+            inputPane.Showing += OnInputPaneShowing;
+            inputPane.Hiding += OnInputPaneHiding;
+
+            this.SizeChanged += OnSizeChanged;
+        }
+        else
+        {
+            VisualStateManager.GoToState(this, "Standard", false);
         }
     }
 
-    public class SheetHidingEventArgs : RoutedEventArgs
+    private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
-        private Deferral _deferral;
-        private TaskCompletionSource<object> _deferralCompletion;
-
-        public Deferral GetDeferral()
-        {
-            _deferralCompletion = new TaskCompletionSource<object>();
-            return (_deferral ??= new Deferral(OnDeferralCompleted));
-        }
-
-        public bool Cancel { get; set; } = false;
-
-        internal Task WaitOnDeferral()
-        {
-            if (_deferral == null)
-                return Task.CompletedTask;
-            else
-                return _deferralCompletion.Task;
-        }
-
-        private void OnDeferralCompleted()
-        {
-            _deferralCompletion?.SetResult(null);
-        }
+        var rightButton = this.FindDescendantByName("PrimaryTitleBarButton");
+        this.OnBottomInsetsChanged(0, rightButton.ActualWidth + 16);
     }
 
-    [ContentProperty(Name = nameof(SheetContent))]
-    public class SheetControl : Control
+    private void OnInputPaneShowing(InputPane sender, InputPaneVisibilityEventArgs args)
     {
-        public object SheetContent
-        {
-            get => (object)GetValue(SheetContentProperty);
-            set => SetValue(SheetContentProperty, value);
-        }
-
-        public static readonly DependencyProperty SheetContentProperty =
-            DependencyProperty.Register("SheetContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
-
-        public DataTemplate SheetContentTemplate
-        {
-            get => (DataTemplate)GetValue(SheetContentTemplateProperty);
-            set => SetValue(SheetContentTemplateProperty, value);
-        }
-
-        public static readonly DependencyProperty SheetContentTemplateProperty =
-            DependencyProperty.Register("SheetContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
-
-        public object TitleContent
-        {
-            get => (object)GetValue(TitleContentProperty);
-            set => SetValue(TitleContentProperty, value);
-        }
-
-        public static readonly DependencyProperty TitleContentProperty =
-            DependencyProperty.Register("TitleContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
-
-        public DataTemplate TitleContentTemplate
-        {
-            get => (DataTemplate)GetValue(TitleContentTemplateProperty);
-            set => SetValue(TitleContentTemplateProperty, value);
-        }
-
-        public static readonly DependencyProperty TitleContentTemplateProperty =
-            DependencyProperty.Register("TitleContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
-
-        public object PrimaryButtonContent
-        {
-            get => (object)GetValue(PrimaryButtonContentProperty);
-            set => SetValue(PrimaryButtonContentProperty, value);
-        }
-
-        public static readonly DependencyProperty PrimaryButtonContentProperty =
-            DependencyProperty.Register("PrimaryButtonContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
-
-        public DataTemplate PrimaryButtonContentTemplate
-        {
-            get => (DataTemplate)GetValue(PrimaryButtonContentTemplateProperty);
-            set => SetValue(PrimaryButtonContentTemplateProperty, value);
-        }
-
-        public static readonly DependencyProperty PrimaryButtonContentTemplateProperty =
-            DependencyProperty.Register("PrimaryButtonContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
-
-        public Visibility PrimaryButtonVisibility
-        {
-            get => (Visibility)GetValue(PrimaryButtonVisibilityProperty);
-            set => SetValue(PrimaryButtonVisibilityProperty, value);
-        }
-
-        public static readonly DependencyProperty PrimaryButtonVisibilityProperty =
-            DependencyProperty.Register("PrimaryButtonVisibility", typeof(Visibility), typeof(SheetControl), new PropertyMetadata(Visibility.Visible));
-
-        public ICommand PrimaryButtonCommand
-        {
-            get => (ICommand)GetValue(PrimaryButtonCommandProperty);
-            set => SetValue(PrimaryButtonCommandProperty, value);
-        }
-
-        public static readonly DependencyProperty PrimaryButtonCommandProperty =
-            DependencyProperty.Register("PrimaryButtonCommand", typeof(ICommand), typeof(SheetControl), new PropertyMetadata(null));
-
-        public bool IsPrimaryButtonEnabled
-        {
-            get => (bool)GetValue(IsPrimaryButtonEnabledProperty);
-            set => SetValue(IsPrimaryButtonEnabledProperty, value);
-        }
-
-        public static readonly DependencyProperty IsPrimaryButtonEnabledProperty =
-            DependencyProperty.Register("IsPrimaryButtonEnabled", typeof(bool), typeof(SheetControl), new PropertyMetadata(true));
-
-        public object SecondaryButtonContent
-        {
-            get => (object)GetValue(SecondaryButtonContentProperty);
-            set => SetValue(SecondaryButtonContentProperty, value);
-        }
-
-        public static readonly DependencyProperty SecondaryButtonContentProperty =
-            DependencyProperty.Register("SecondaryButtonContent", typeof(object), typeof(SheetControl), new PropertyMetadata(null));
-
-        public DataTemplate SecondaryButtonContentTemplate
-        {
-            get => (DataTemplate)GetValue(SecondaryButtonContentTemplateProperty);
-            set => SetValue(SecondaryButtonContentTemplateProperty, value);
-        }
-
-        public static readonly DependencyProperty SecondaryButtonContentTemplateProperty =
-            DependencyProperty.Register("SecondaryButtonContentTemplate", typeof(DataTemplate), typeof(SheetControl), new PropertyMetadata(null));
-
-        public Visibility SecondaryButtonVisibility
-        {
-            get => (Visibility)GetValue(SecondaryButtonVisibilityProperty);
-            set => SetValue(SecondaryButtonVisibilityProperty, value);
-        }
-
-        public static readonly DependencyProperty SecondaryButtonVisibilityProperty =
-            DependencyProperty.Register("SecondaryButtonVisibility", typeof(Visibility), typeof(SheetControl), new PropertyMetadata(Visibility.Visible));
-
-        public ICommand SecondaryButtonCommand
-        {
-            get => (ICommand)GetValue(SecondaryButtonCommandProperty);
-            set => SetValue(SecondaryButtonCommandProperty, value);
-        }
-
-        public static readonly DependencyProperty SecondaryButtonCommandProperty =
-            DependencyProperty.Register("SecondaryButtonCommand", typeof(ICommand), typeof(SheetControl), new PropertyMetadata(null));
-
-        public bool IsSecondaryButtonEnabled
-        {
-            get => (bool)GetValue(IsSecondaryButtonEnabledProperty);
-            set => SetValue(IsSecondaryButtonEnabledProperty, value);
-        }
-
-        public static readonly DependencyProperty IsSecondaryButtonEnabledProperty =
-            DependencyProperty.Register("IsSecondaryButtonEnabled", typeof(bool), typeof(SheetControl), new PropertyMetadata(true));
-
-        public Size PreferredWindowSize
-        {
-            get { return (Size)GetValue(PreferredWindowSizeProperty); }
-            set { SetValue(PreferredWindowSizeProperty, value); }
-        }
-
-        // Using a DependencyProperty as the backing store for PreferredWindowSize.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty PreferredWindowSizeProperty =
-            DependencyProperty.Register("PreferredWindowSize", typeof(Size), typeof(SheetControl), new PropertyMetadata(new Size(320, 400)));
-
-
-        public event TypedEventHandler<SheetControl, SheetShowingEventArgs> Showing;
-        public event TypedEventHandler<SheetControl, RoutedEventArgs> Shown;
-        public event TypedEventHandler<SheetControl, SheetHidingEventArgs> Hiding;
-        public event TypedEventHandler<SheetControl, RoutedEventArgs> Hidden;
-
-        public ISheetController Controller { get; private set; }
-
-        public SheetControl()
-        {
-            this.DefaultStyleKey = typeof(SheetControl);
-
-            // default hide
-            this.SecondaryButtonCommand = new AsyncRelayCommand(() =>
-            {
-                return Controller?.TryHideSheetAsync();
-            });
-        }
-
-        internal void SetSheetController(ISheetController controller)
-        {
-            Controller = controller;
-        }
-
-        protected override void OnApplyTemplate()
-        {
-            base.OnApplyTemplate();
-
-            if (Controller != null && Controller.IsFullWindow)
-            {
-                VisualStateManager.GoToState(this, "FullWindow", false);
-                var titleBarDragArea = this.FindDescendantByName("TitleBarDragArea");
-                Controller.SafeAreaService.SafeAreaUpdated += OnSafeAreaUpdated;
-                Controller.SafeAreaService.SetTitleBar(titleBarDragArea);
-
-                var inputPane = InputPane.GetForCurrentView();
-                inputPane.Showing += OnInputPaneShowing;
-                inputPane.Hiding += OnInputPaneHiding;
-
-                this.SizeChanged += OnSizeChanged;
-            }
-            else
-            {
-                VisualStateManager.GoToState(this, "Standard", false);
-            }
-        }
-
-        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            var rightButton = this.FindDescendantByName("PrimaryTitleBarButton");
-            this.OnBottomInsetsChanged(0, rightButton.ActualWidth + 16);
-        }
-
-        internal void InvokeShowing(object parameter)
-        {
-            Showing?.Invoke(this, new SheetShowingEventArgs(parameter));
-        }
-
-        internal async Task<bool> InvokeHidingAsync()
-        {
-            var ev = new SheetHidingEventArgs();
-            Hiding?.Invoke(this, ev);
-
-            await ev.WaitOnDeferral();
-
-            return !ev.Cancel;
-        }
-
-        internal void InvokeShown()
-        {
-            Shown?.Invoke(this, new RoutedEventArgs());
-        }
-
-        internal void InvokeHidden()
-        {
-            if (Controller.IsFullWindow)
-            {
-                Controller.SafeAreaService.SafeAreaUpdated += OnSafeAreaUpdated;
-            }
-
-            Hidden?.Invoke(this, new RoutedEventArgs());
-        }
-
-        private void OnInputPaneShowing(InputPane sender, InputPaneVisibilityEventArgs args)
-        {
-            var ButtonsGrid = (Grid)this.FindDescendantByName("ButtonsGrid");
-            ButtonsGrid.Margin = new Thickness(0, 0, 0, args.OccludedRect.Height);
-            args.EnsuredFocusedElementInView = true;
-        }
-
-        private void OnInputPaneHiding(InputPane sender, InputPaneVisibilityEventArgs args)
-        {
-            var ButtonsGrid = (Grid)this.FindDescendantByName("ButtonsGrid");
-            ButtonsGrid.Margin = new Thickness(0, 0, 0, args.OccludedRect.Height);
-            args.EnsuredFocusedElementInView = true;
-        }
-
-        private void OnSafeAreaUpdated(object sender, SafeAreaUpdatedEventArgs e)
-        {
-            var titleBarGrid = (Grid)this.FindDescendantByName("TitleBarGrid");
-
-            if (e.SafeArea.HasTitleBar)
-            {
-                titleBarGrid.Height = e.SafeArea.Bounds.Top;
-                titleBarGrid.Padding = new Thickness();
-            }
-            else
-            {
-                titleBarGrid.Height = 42;
-                titleBarGrid.Padding = new Thickness(0, e.SafeArea.Bounds.Top, 0, 4);
-            }
-
-            Margin = new Thickness(e.SafeArea.Bounds.Left, 0, e.SafeArea.Bounds.Right, e.SafeArea.Bounds.Bottom);
-        }
-
-        protected virtual void OnBottomInsetsChanged(double leftInset, double rightInset) { }
+        var ButtonsGrid = (Grid)this.FindDescendantByName("ButtonsGrid");
+        ButtonsGrid.Margin = new Thickness(0, 0, 0, args.OccludedRect.Height);
+        args.EnsuredFocusedElementInView = true;
     }
+
+    private void OnInputPaneHiding(InputPane sender, InputPaneVisibilityEventArgs args)
+    {
+        var ButtonsGrid = (Grid)this.FindDescendantByName("ButtonsGrid");
+        ButtonsGrid.Margin = new Thickness(0, 0, 0, args.OccludedRect.Height);
+        args.EnsuredFocusedElementInView = true;
+    }
+
+    private void OnSafeAreaUpdated(object sender, SafeAreaUpdatedEventArgs e)
+    {
+        var titleBarGrid = (Grid)this.FindDescendantByName("TitleBarGrid");
+
+        if (e.SafeArea.HasTitleBar)
+        {
+            titleBarGrid.Height = e.SafeArea.Bounds.Top;
+            titleBarGrid.Padding = new Thickness();
+        }
+        else
+        {
+            titleBarGrid.Height = 42;
+            titleBarGrid.Padding = new Thickness(0, e.SafeArea.Bounds.Top, 0, 4);
+        }
+
+        Margin = new Thickness(e.SafeArea.Bounds.Left, 0, e.SafeArea.Bounds.Right, e.SafeArea.Bounds.Bottom);
+    }
+
+    protected virtual void OnBottomInsetsChanged(double leftInset, double rightInset) { }
 }

--- a/UniSky/Controls/Sheet/SheetControl.xaml
+++ b/UniSky/Controls/Sheet/SheetControl.xaml
@@ -50,8 +50,8 @@
                                               VerticalAlignment="Stretch"
                                               HorizontalContentAlignment="Stretch"
                                               VerticalContentAlignment="Stretch"
-                                              Content="{TemplateBinding SheetContent}"
-                                              ContentTemplate="{TemplateBinding SheetContentTemplate}"/>
+                                              Content="{TemplateBinding OverlayContent}"
+                                              ContentTemplate="{TemplateBinding OverlayContentTemplate}"/>
 
                             <Grid x:Name="ButtonsGrid"
                                   VerticalAlignment="Top"

--- a/UniSky/Controls/Sheet/SheetRootControl.xaml.cs
+++ b/UniSky/Controls/Sheet/SheetRootControl.xaml.cs
@@ -68,8 +68,6 @@ namespace UniSky.Controls.Sheet
 
             VisualStateManager.GoToState(this, "Open", true);
 
-            Window.Current.SetTitleBar(TitleBar);
-
             var safeAreaService = ServiceContainer.Scoped.GetRequiredService<ISafeAreaService>();
             safeAreaService.SafeAreaUpdated += OnSafeAreaUpdated;
 

--- a/UniSky/Pages/NotificationsPage.xaml.cs
+++ b/UniSky/Pages/NotificationsPage.xaml.cs
@@ -14,8 +14,8 @@ public sealed partial class NotificationsPage : Page
 {
     public NotificationsPageViewModel ViewModel
     {
-        get { return (NotificationsPageViewModel)GetValue(ViewModelProperty); }
-        set { SetValue(ViewModelProperty, value); }
+        get => (NotificationsPageViewModel)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
     }
 
     public static readonly DependencyProperty ViewModelProperty =

--- a/UniSky/Pages/ProfilePage.xaml.cs
+++ b/UniSky/Pages/ProfilePage.xaml.cs
@@ -45,8 +45,8 @@ public sealed partial class ProfilePage : Page
 
     public ProfilePageViewModel ViewModel
     {
-        get { return (ProfilePageViewModel)GetValue(ViewModelProperty); }
-        set { SetValue(ViewModelProperty, value); }
+        get => (ProfilePageViewModel)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
     }
 
     public static readonly DependencyProperty ViewModelProperty =

--- a/UniSky/Pages/SearchPage.xaml.cs
+++ b/UniSky/Pages/SearchPage.xaml.cs
@@ -15,8 +15,8 @@ public sealed partial class SearchPage : Page
 {
     public SearchPageViewModel ViewModel
     {
-        get { return (SearchPageViewModel)GetValue(ViewModelProperty); }
-        set { SetValue(ViewModelProperty, value); }
+        get => (SearchPageViewModel)GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
     }
 
     public static readonly DependencyProperty ViewModelProperty =

--- a/UniSky/Resources/en-GB/Resources.resw
+++ b/UniSky/Resources/en-GB/Resources.resw
@@ -209,7 +209,7 @@
   <data name="ComposeSheetSecondaryText.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="ComposeSheetTitle.Text" xml:space="preserve">
+  <data name="ComposeSheet.TitleContent" xml:space="preserve">
     <value>NEW POST</value>
   </data>
   <data name="E_FileUnavailable" xml:space="preserve">

--- a/UniSky/Resources/en-GB/custom-twitter/Resources.resw
+++ b/UniSky/Resources/en-GB/custom-twitter/Resources.resw
@@ -159,7 +159,7 @@
   <data name="ComposeSheetPrimaryText.Text" xml:space="preserve">
     <value>Tweet</value>
   </data>
-  <data name="ComposeSheetTitle.Text" xml:space="preserve">
+  <data name="ComposeSheet.TitleContent" xml:space="preserve">
     <value>NEW TWEET</value>
   </data>
   <data name="Notification_LikedTweetMultiple" xml:space="preserve">

--- a/UniSky/Services/ISheetService.cs
+++ b/UniSky/Services/ISheetService.cs
@@ -6,7 +6,7 @@ namespace UniSky.Services
 {
     public interface ISheetService
     {
-        Task<ISheetController> ShowAsync<T>(object parameter = null) where T : SheetControl, new();
-        Task<ISheetController> ShowAsync<T>(Func<SheetControl> factory, object parameter = null) where T : SheetControl;
+        Task<IOverlayController> ShowAsync<T>(object parameter = null) where T : SheetControl, new();
+        Task<IOverlayController> ShowAsync<T>(Func<SheetControl> factory, object parameter = null) where T : SheetControl;
     }
 }

--- a/UniSky/Services/Overlay/AppWindowOverlayController.cs
+++ b/UniSky/Services/Overlay/AppWindowOverlayController.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using UniSky.Controls.Sheet;
+using UniSky.Controls.Overlay;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
@@ -9,15 +9,16 @@ using Windows.UI.Xaml;
 
 namespace UniSky.Services;
 
-public class AppWindowSheetController : ISheetController
+public class AppWindowOverlayController : IOverlayController
 {
     private readonly AppWindow appWindow;
-    private readonly SheetControl control;
+    private readonly OverlayControl control;
     private readonly ISettingsService settingsService;
 
     private readonly string settingsKey;
+    private readonly long titlePropertyChangedRef;
 
-    public AppWindowSheetController(AppWindow window, SheetControl control)
+    public AppWindowOverlayController(AppWindow window, OverlayControl control)
     {
         this.appWindow = window;
         this.control = control;
@@ -34,6 +35,9 @@ public class AppWindowSheetController : ISheetController
         appWindow.RequestSize(initialSize);
 
         PlaceAppWindow(initialSize);
+
+        this.titlePropertyChangedRef = this.control.RegisterPropertyChangedCallback(OverlayControl.TitleContentProperty, OnTitleChanged);
+        OnTitleChanged(this.control, OverlayControl.TitleContentProperty);
     }
 
     public UIElement Root => control;
@@ -62,6 +66,7 @@ public class AppWindowSheetController : ISheetController
 
     private void OnClosed(AppWindow sender, AppWindowClosedEventArgs args)
     {
+        control.UnregisterPropertyChangedCallback(OverlayControl.TitleContentProperty, titlePropertyChangedRef);
         control.InvokeHidden();
     }
 
@@ -72,6 +77,14 @@ public class AppWindowSheetController : ISheetController
             var settingsKey = "AppWindow_LastSize_" + control.GetType().FullName.Replace(".", "_");
             settingsService.Save(settingsKey, new Size(control.ActualSize.X, control.ActualSize.Y));
         }
+    }
+
+    private void OnTitleChanged(DependencyObject sender, DependencyProperty dp)
+    {
+        if (dp != OverlayControl.TitleContentProperty)
+            return;
+
+        appWindow.Title = control.TitleContent?.ToString() ?? "";
     }
 
     private void PlaceAppWindow(Size initialSize)

--- a/UniSky/Services/Overlay/ApplicationViewOverlayController.cs
+++ b/UniSky/Services/Overlay/ApplicationViewOverlayController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using UniSky.Controls.Overlay;
 using UniSky.Controls.Sheet;
 using Windows.Foundation.Metadata;
 using Windows.UI.Core;
@@ -10,19 +11,20 @@ using Windows.UI.Xaml;
 
 namespace UniSky.Services;
 
-internal class ApplicationViewSheetController : ISheetController
+internal class ApplicationViewOverlayController : IOverlayController
 {
-    private readonly SheetControl control;
+    private readonly OverlayControl control;
     private readonly int hostViewId;
     private readonly int viewId;
     private readonly ISettingsService settingsService;
 
     private readonly string settingsKey;
     private bool hasActivated = false;
+    private long titlePropertyChangedRef;
 
-    public ApplicationViewSheetController(SheetControl control,
-                                          int hostViewId,
-                                          int viewId)
+    public ApplicationViewOverlayController(OverlayControl control,
+                                            int hostViewId,
+                                            int viewId)
     {
         this.control = control;
         this.hostViewId = hostViewId;
@@ -47,6 +49,18 @@ internal class ApplicationViewSheetController : ISheetController
         coreWindow.SizeChanged += OnWindowSizeChanged;
         coreWindow.Activated += OnActivated;
         coreWindow.Closed += OnWindowClosed;
+
+        titlePropertyChangedRef = control.RegisterPropertyChangedCallback(OverlayControl.TitleContentProperty, OnTitleChanged);
+        OnTitleChanged(control, OverlayControl.TitleContentProperty);
+    }
+
+    private void OnTitleChanged(DependencyObject sender, DependencyProperty dp)
+    {
+        if (dp != OverlayControl.TitleContentProperty)
+            return;
+
+        var applicationView = ApplicationView.GetForCurrentView();
+        applicationView.Title = control.TitleContent?.ToString() ?? "";
     }
 
     private void OnActivated(CoreWindow sender, WindowActivatedEventArgs args)
@@ -70,6 +84,7 @@ internal class ApplicationViewSheetController : ISheetController
         if (await control.InvokeHidingAsync())
         {
             await ApplicationViewSwitcher.SwitchAsync(hostViewId, viewId, ApplicationViewSwitchingOptions.ConsolidateViews);
+            this.control.UnregisterPropertyChangedCallback(OverlayControl.TitleContentProperty, this.titlePropertyChangedRef);
             return true;
         }
 

--- a/UniSky/Services/Overlay/IOverlayController.cs
+++ b/UniSky/Services/Overlay/IOverlayController.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml;
 
 namespace UniSky.Services;
 
-public interface ISheetController
+public interface IOverlayController
 {
     UIElement Root { get; } 
     bool IsFullWindow { get; }

--- a/UniSky/Services/Overlay/OverlayService.cs
+++ b/UniSky/Services/Overlay/OverlayService.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UniSky.Controls.Overlay;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.WindowManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Hosting;
+
+namespace UniSky.Services.Overlay;
+
+public abstract class OverlayService
+{
+    protected async Task<IOverlayController> ShowOverlayForAppWindow<T>(Func<OverlayControl> factory, object parameter) where T : OverlayControl
+    {
+        var control = factory();
+        var appWindow = await AppWindow.TryCreateAsync();
+
+        var controller = new AppWindowOverlayController(appWindow, control);
+        control.SetOverlayController(controller);
+        control.InvokeShowing(parameter);
+
+        ElementCompositionPreview.SetAppWindowContent(appWindow, control);
+
+        await appWindow.TryShowAsync();
+
+        control.InvokeShown();
+
+        return controller;
+    }
+
+    protected async Task<IOverlayController> ShowOverlayForCoreWindow<T>(Func<OverlayControl> factory, object parameter) where T : OverlayControl
+    {
+        IOverlayController controller = null;
+
+        var currentViewId = ApplicationView.GetForCurrentView().Id;
+        var view = CoreApplication.CreateNewView();
+        var newViewId = 0;
+        await view.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+        {
+            newViewId = ApplicationView.GetForCurrentView().Id;
+
+            var control = factory();
+            controller = new ApplicationViewOverlayController(control, currentViewId, newViewId);
+            control.SetOverlayController(controller);
+
+            Window.Current.Content = control;
+            Window.Current.Activate();
+
+            control.InvokeShowing(parameter);
+            control.InvokeShown();
+        });
+
+        await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newViewId, ViewSizePreference.UseMinimum);
+
+        return controller;
+    }
+}

--- a/UniSky/Services/SafeArea/ApplicationViewSafeAreaService.cs
+++ b/UniSky/Services/SafeArea/ApplicationViewSafeAreaService.cs
@@ -11,14 +11,7 @@ using Windows.UI.Xaml;
 
 namespace UniSky.Services;
 
-public record class SafeAreaInfo(bool HasTitleBar, bool IsActive, Thickness Bounds, ElementTheme Theme);
-
-public class SafeAreaUpdatedEventArgs : EventArgs
-{
-    public SafeAreaInfo SafeArea { get; init; }
-}
-
-internal class CoreWindowSafeAreaService : ISafeAreaService
+internal class ApplicationViewSafeAreaService : ISafeAreaService
 {
     private readonly CoreWindow _window;
     private readonly ApplicationView _applicationView;
@@ -32,7 +25,7 @@ internal class CoreWindowSafeAreaService : ISafeAreaService
     public SafeAreaInfo State
         => _state;
 
-    public CoreWindowSafeAreaService()
+    public ApplicationViewSafeAreaService()
     {
         _window = CoreWindow.GetForCurrentThread();
         _window.SizeChanged += CoreWindow_SizeChanged;

--- a/UniSky/Services/SafeArea/SafeAreaInfo.cs
+++ b/UniSky/Services/SafeArea/SafeAreaInfo.cs
@@ -1,0 +1,5 @@
+﻿using Windows.UI.Xaml;
+
+namespace UniSky.Services;
+
+public record class SafeAreaInfo(bool HasTitleBar, bool IsActive, Thickness Bounds, ElementTheme Theme);

--- a/UniSky/Services/SafeArea/SafeAreaUpdatedEventArgs.cs
+++ b/UniSky/Services/SafeArea/SafeAreaUpdatedEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace UniSky.Services;
+
+public class SafeAreaUpdatedEventArgs : EventArgs
+{
+    public SafeAreaInfo SafeArea { get; init; }
+}

--- a/UniSky/Services/Sheet/SheetRootController.cs
+++ b/UniSky/Services/Sheet/SheetRootController.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml;
 namespace UniSky.Services;
 
 public class SheetRootController(SheetRootControl rootControl,
-                                 ISafeAreaService safeAreaService) : ISheetController
+                                 ISafeAreaService safeAreaService) : IOverlayController
 {
     public UIElement Root => rootControl;
     public bool IsFullWindow => false;

--- a/UniSky/Services/Sheet/SheetService.cs
+++ b/UniSky/Services/Sheet/SheetService.cs
@@ -2,11 +2,12 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using UniSky.Controls.Overlay;
 using UniSky.Controls.Sheet;
+using UniSky.Services.Overlay;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
-using Windows.System.Profile;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
@@ -15,7 +16,7 @@ using Windows.UI.Xaml.Hosting;
 
 namespace UniSky.Services;
 
-internal class SheetService : ISheetService
+internal class SheetService : OverlayService, ISheetService
 {
     private readonly SheetRootControl sheetRoot;
     private readonly ITypedSettings settingsService;
@@ -26,10 +27,10 @@ internal class SheetService : ISheetService
         this.sheetRoot = Window.Current.Content.FindDescendant<SheetRootControl>();
     }
 
-    public Task<ISheetController> ShowAsync<T>(object parameter = null) where T : SheetControl, new()
+    public Task<IOverlayController> ShowAsync<T>(object parameter = null) where T : SheetControl, new()
         => ShowAsync<T>(() => new T(), parameter);
 
-    public async Task<ISheetController> ShowAsync<T>(Func<SheetControl> factory, object parameter = null) where T : SheetControl
+    public async Task<IOverlayController> ShowAsync<T>(Func<SheetControl> factory, object parameter = null) where T : SheetControl
     {
         if (sheetRoot != null && !settingsService.UseMultipleWindows)
         {
@@ -38,7 +39,7 @@ internal class SheetService : ISheetService
             var control = factory();
             var controller = new SheetRootController(sheetRoot, safeArea);
 
-            control.SetSheetController(controller);
+            control.SetOverlayController(controller);
 
             sheetRoot.ShowSheet(control, parameter);
             return controller;
@@ -47,57 +48,12 @@ internal class SheetService : ISheetService
         {
             if (ApiInformation.IsApiContractPresent(typeof(UniversalApiContract).FullName, 8, 0))
             {
-                return await ShowSheetForAppWindow<T>(factory, parameter);
+                return await ShowOverlayForAppWindow<T>(factory, parameter);
             }
             else
             {
-                return await ShowSheetForCoreWindow<T>(factory, parameter);
+                return await ShowOverlayForCoreWindow<T>(factory, parameter);
             }
         }
-    }
-
-    private async Task<ISheetController> ShowSheetForAppWindow<T>(Func<SheetControl> factory, object parameter) where T : SheetControl
-    {
-        var control = factory();
-        var appWindow = await AppWindow.TryCreateAsync();
-
-        var controller = new AppWindowSheetController(appWindow, control);
-        control.SetSheetController(controller);
-        control.InvokeShowing(parameter);
-
-        ElementCompositionPreview.SetAppWindowContent(appWindow, control);
-
-        await appWindow.TryShowAsync();
-
-        control.InvokeShown();
-
-        return controller;
-    }
-
-    private static async Task<ISheetController> ShowSheetForCoreWindow<T>(Func<SheetControl> factory, object parameter) where T : SheetControl
-    {
-        ISheetController controller = null;
-
-        var currentViewId = ApplicationView.GetForCurrentView().Id;
-        var view = CoreApplication.CreateNewView();
-        var newViewId = 0;
-        await view.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-        {
-            newViewId = ApplicationView.GetForCurrentView().Id;
-
-            var control = factory();
-            controller = new ApplicationViewSheetController(control, currentViewId, newViewId);
-            control.SetSheetController(controller);
-
-            Window.Current.Content = control;
-            Window.Current.Activate();
-
-            control.InvokeShowing(parameter);
-            control.InvokeShown();
-        });
-
-        await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newViewId, ViewSizePreference.UseMinimum);
-
-        return controller;
     }
 }

--- a/UniSky/UniSky.csproj
+++ b/UniSky/UniSky.csproj
@@ -172,6 +172,9 @@
     <Compile Include="Controls\Settings\SettingsSheet.xaml.cs">
       <DependentUpon>SettingsSheet.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Overlay\OverlayHidingEventArgs.cs" />
+    <Compile Include="Controls\Overlay\OverlayShowingEventArgs.cs" />
+    <Compile Include="Controls\Overlay\OverlayControl.cs" />
     <Compile Include="Controls\Sheet\SheetControl.cs" />
     <Compile Include="Controls\Sheet\SheetRootControl.xaml.cs">
       <DependentUpon>SheetRootControl.xaml</DependentUpon>
@@ -247,14 +250,17 @@
     <Compile Include="DataTemplates\FeedTemplates.xaml.cs">
       <DependentUpon>FeedTemplates.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Services\Overlay\OverlayService.cs" />
     <Compile Include="Services\SafeArea\AppWindowSafeAreaService.cs" />
-    <Compile Include="Services\SafeArea\CoreWindowSafeAreaService.cs" />
+    <Compile Include="Services\SafeArea\ApplicationViewSafeAreaService.cs" />
     <Compile Include="Services\SafeArea\ISafeAreaService.cs" />
+    <Compile Include="Services\SafeArea\SafeAreaInfo.cs" />
+    <Compile Include="Services\SafeArea\SafeAreaUpdatedEventArgs.cs" />
     <Compile Include="Services\ServiceContainer.cs" />
     <Compile Include="Services\SettingsService.cs" />
-    <Compile Include="Services\Sheet\ApplicationViewSheetController.cs" />
-    <Compile Include="Services\Sheet\AppWindowSheetController.cs" />
-    <Compile Include="Services\Sheet\ISheetController.cs" />
+    <Compile Include="Services\Overlay\ApplicationViewOverlayController.cs" />
+    <Compile Include="Services\Overlay\AppWindowOverlayController.cs" />
+    <Compile Include="Services\Overlay\IOverlayController.cs" />
     <Compile Include="Services\Sheet\SheetRootController.cs" />
     <Compile Include="Services\Sheet\SheetService.cs" />
     <Compile Include="Services\ThemeService.cs" />

--- a/UniSky/ViewModels/Compose/ComposeViewModel.cs
+++ b/UniSky/ViewModels/Compose/ComposeViewModel.cs
@@ -67,10 +67,10 @@ public partial class ComposeViewModel : ViewModelBase
     public bool HasAttachments
         => AttachedFiles.Count > 0;
 
-    public ISheetController SheetController { get; }
+    public IOverlayController SheetController { get; }
 
     public ComposeViewModel(IProtocolService protocolService,
-                            ISheetController sheetController,
+                            IOverlayController sheetController,
                             ILogger<ComposeViewModel> logger,
                             PostViewModel replyTo = null)
     {


### PR DESCRIPTION
Splits sheets into a more generic "Overlay" class, allowing the reuse of the windowing logic in future overlays like the gallery.